### PR TITLE
fix: prevent border flicker from IME candidate updates

### DIFF
--- a/src/event_hook.rs
+++ b/src/event_hook.rs
@@ -12,7 +12,7 @@ use crate::APP_STATE;
 use crate::utils::{
     LogIfErr, WM_APP_FOREGROUND, WM_APP_LOCATIONCHANGE, WM_APP_MINIMIZEEND, WM_APP_MINIMIZESTART,
     WM_APP_REORDER, destroy_border_for_window, get_border_for_window, get_foreground_window,
-    has_filtered_style, hide_border_for_window, is_window_visible, post_message_w,
+    get_window_process_name, hide_border_for_window, is_window_visible, post_message_w,
     send_notify_message_w, show_border_for_window,
 };
 
@@ -43,20 +43,27 @@ pub extern "system" fn process_win_event(
             }
         }
         EVENT_OBJECT_REORDER => {
-            // Tool and no-activate windows (such as IME candidate windows) emit reorder events
-            // whenever their contents change. Only the border belonging to the window reported
-            // by the event can be affected; broadcasting this to every border makes the border
-            // fight unrelated popups and causes visible flicker.
-            if _id_object != OBJID_CLIENT.0 || has_filtered_style(_hwnd) {
+            // Rime's Weasel candidate window emits reorder events whenever its contents change.
+            // Ignore those content updates without suppressing reorder handling for other tool
+            // windows, which users can force-enable through window rules.
+            if _id_object != OBJID_CLIENT.0 {
+                return;
+            }
+            if get_window_process_name(_hwnd)
+                .is_ok_and(|name| name.eq_ignore_ascii_case("WeaselServer"))
+            {
                 return;
             }
 
-            if let Some(border_window) = get_border_for_window(_hwnd)
-                && is_window_visible(border_window)
-            {
-                post_message_w(Some(border_window), WM_APP_REORDER, WPARAM(0), LPARAM(0))
-                    .context("EVENT_OBJECT_REORDER")
-                    .log_if_err();
+            // The HWND for foreground-related reorder events does not reliably identify the
+            // foreground window, so all visible borders need to verify their Z-order.
+            for value in APP_STATE.borders.lock().unwrap().values() {
+                let border_window = HWND(*value as _);
+                if is_window_visible(border_window) {
+                    post_message_w(Some(border_window), WM_APP_REORDER, WPARAM(0), LPARAM(0))
+                        .context("EVENT_OBJECT_REORDER")
+                        .log_if_err();
+                }
             }
         }
         // Neither the HWND passed by this event nor the one returned by GetForegroundWindow() are
@@ -103,10 +110,10 @@ pub extern "system" fn process_win_event(
 pub fn handle_foreground_event(best_hwnd_guess: HWND, other_hwnd_guess: HWND) {
     let mut active_window = APP_STATE.active_window.lock().unwrap();
     let current_active_hwnd = HWND(*active_window as _);
-    let new_active_hwnd = [best_hwnd_guess, other_hwnd_guess]
-        .into_iter()
-        .find(|hwnd| !hwnd.is_invalid() && !has_filtered_style(*hwnd))
-        .unwrap_or(current_active_hwnd);
+    let new_active_hwnd = match !best_hwnd_guess.is_invalid() {
+        true => best_hwnd_guess,
+        false => other_hwnd_guess,
+    };
 
     // WinEvent can report the same foreground window repeatedly, notably while an IME updates
     // its candidate popup. Avoid needlessly re-rendering every border in that case.

--- a/src/event_hook.rs
+++ b/src/event_hook.rs
@@ -12,8 +12,8 @@ use crate::APP_STATE;
 use crate::utils::{
     LogIfErr, WM_APP_FOREGROUND, WM_APP_LOCATIONCHANGE, WM_APP_MINIMIZEEND, WM_APP_MINIMIZESTART,
     WM_APP_REORDER, destroy_border_for_window, get_border_for_window, get_foreground_window,
-    hide_border_for_window, is_window_visible, post_message_w, send_notify_message_w,
-    show_border_for_window,
+    has_filtered_style, hide_border_for_window, is_window_visible, post_message_w,
+    send_notify_message_w, show_border_for_window,
 };
 
 pub extern "system" fn process_win_event(
@@ -43,19 +43,20 @@ pub extern "system" fn process_win_event(
             }
         }
         EVENT_OBJECT_REORDER => {
-            // Ignore OBJIDs not needed for window Z-order handling.
-            if _id_object != OBJID_CLIENT.0 {
+            // Tool and no-activate windows (such as IME candidate windows) emit reorder events
+            // whenever their contents change. Only the border belonging to the window reported
+            // by the event can be affected; broadcasting this to every border makes the border
+            // fight unrelated popups and causes visible flicker.
+            if _id_object != OBJID_CLIENT.0 || has_filtered_style(_hwnd) {
                 return;
             }
 
-            // Send reorder messages to all the border windows
-            for value in APP_STATE.borders.lock().unwrap().values() {
-                let border_window = HWND(*value as _);
-                if is_window_visible(border_window) {
-                    post_message_w(Some(border_window), WM_APP_REORDER, WPARAM(0), LPARAM(0))
-                        .context("EVENT_OBJECT_REORDER")
-                        .log_if_err();
-                }
+            if let Some(border_window) = get_border_for_window(_hwnd)
+                && is_window_visible(border_window)
+            {
+                post_message_w(Some(border_window), WM_APP_REORDER, WPARAM(0), LPARAM(0))
+                    .context("EVENT_OBJECT_REORDER")
+                    .log_if_err();
             }
         }
         // Neither the HWND passed by this event nor the one returned by GetForegroundWindow() are
@@ -100,11 +101,21 @@ pub extern "system" fn process_win_event(
 }
 
 pub fn handle_foreground_event(best_hwnd_guess: HWND, other_hwnd_guess: HWND) {
-    let new_active_hwnd = match !best_hwnd_guess.is_invalid() {
-        true => best_hwnd_guess,
-        false => other_hwnd_guess,
-    };
-    *APP_STATE.active_window.lock().unwrap() = new_active_hwnd.0 as isize;
+    let mut active_window = APP_STATE.active_window.lock().unwrap();
+    let current_active_hwnd = HWND(*active_window as _);
+    let new_active_hwnd = [best_hwnd_guess, other_hwnd_guess]
+        .into_iter()
+        .find(|hwnd| !hwnd.is_invalid() && !has_filtered_style(*hwnd))
+        .unwrap_or(current_active_hwnd);
+
+    // WinEvent can report the same foreground window repeatedly, notably while an IME updates
+    // its candidate popup. Avoid needlessly re-rendering every border in that case.
+    if new_active_hwnd.is_invalid() || new_active_hwnd == current_active_hwnd {
+        return;
+    }
+
+    *active_window = new_active_hwnd.0 as isize;
+    drop(active_window);
 
     // Send foreground messages to all the border windows
     // TODO: I think only the previous focused and new focused actually need the message

--- a/src/event_hook.rs
+++ b/src/event_hook.rs
@@ -4,16 +4,16 @@ use windows::Win32::UI::Accessibility::HWINEVENTHOOK;
 use windows::Win32::UI::WindowsAndMessaging::{
     CHILDID_SELF, EVENT_OBJECT_CLOAKED, EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE,
     EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_REORDER, EVENT_OBJECT_SHOW, EVENT_OBJECT_UNCLOAKED,
-    EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_MINIMIZEEND, EVENT_SYSTEM_MINIMIZESTART, OBJID_CLIENT,
-    OBJID_CURSOR, OBJID_WINDOW,
+    EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_MINIMIZEEND, EVENT_SYSTEM_MINIMIZESTART,
+    GetDesktopWindow, OBJID_CLIENT, OBJID_CURSOR, OBJID_WINDOW,
 };
 
 use crate::APP_STATE;
 use crate::utils::{
     LogIfErr, WM_APP_FOREGROUND, WM_APP_LOCATIONCHANGE, WM_APP_MINIMIZEEND, WM_APP_MINIMIZESTART,
     WM_APP_REORDER, destroy_border_for_window, get_border_for_window, get_foreground_window,
-    get_window_process_name, hide_border_for_window, is_window_visible, post_message_w,
-    send_notify_message_w, show_border_for_window,
+    hide_border_for_window, is_window_visible, post_message_w, send_notify_message_w,
+    show_border_for_window,
 };
 
 pub extern "system" fn process_win_event(
@@ -43,15 +43,11 @@ pub extern "system" fn process_win_event(
             }
         }
         EVENT_OBJECT_REORDER => {
-            // Rime's Weasel candidate window emits reorder events whenever its contents change.
-            // Ignore those content updates without suppressing reorder handling for other tool
-            // windows, which users can force-enable through window rules.
-            if _id_object != OBJID_CLIENT.0 {
-                return;
-            }
-            if get_window_process_name(_hwnd)
-                .is_ok_and(|name| name.eq_ignore_ascii_case("WeaselServer"))
-            {
+            // We only care about reorders of top-level windows, which surface as client-object
+            // reorder events on the desktop window. This filters out content reorders from
+            // individual windows, such as IME candidate popups that reorder their contents on
+            // every update.
+            if _id_object != OBJID_CLIENT.0 || _hwnd != unsafe { GetDesktopWindow() } {
                 return;
             }
 

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -20,8 +20,8 @@ use windows::Win32::UI::HiDpi::MDT_DEFAULT;
 use windows::Win32::UI::WindowsAndMessaging::{
     CREATESTRUCTW, CW_USEDEFAULT, CreateWindowExW, DBT_DEVNODES_CHANGED, DefWindowProcW,
     GW_HWNDNEXT, GW_HWNDPREV, GWLP_USERDATA, GetSystemMetrics, GetWindow, GetWindowLongPtrW,
-    HWND_TOP, KillTimer, LWA_ALPHA, MSG, PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND,
-    PBT_APMSUSPEND, PM_REMOVE, PeekMessageW, PostQuitMessage, SET_WINDOW_POS_FLAGS,
+    HWND_NOTOPMOST, HWND_TOPMOST, KillTimer, LWA_ALPHA, PBT_APMRESUMEAUTOMATIC,
+    PBT_APMRESUMESUSPEND, PBT_APMSUSPEND, PostQuitMessage, SET_WINDOW_POS_FLAGS,
     SM_CXVIRTUALSCREEN, SWP_HIDEWINDOW, SWP_NOACTIVATE, SWP_NOREDRAW, SWP_NOSENDCHANGING,
     SWP_NOZORDER, SWP_SHOWWINDOW, SetLayeredWindowAttributes, SetTimer, SetWindowLongPtrW,
     SetWindowPos, WM_CREATE, WM_DEVICECHANGE, WM_DISPLAYCHANGE, WM_DPICHANGED, WM_NCDESTROY,
@@ -53,6 +53,7 @@ use crate::utils::{
 use crate::{APP_STATE, BG_SERVICES};
 
 const REORDER_TIMER_ID: usize = 0;
+const REORDER_DEBOUNCE_DELAY_MS: u32 = 30;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub enum WindowState {
@@ -84,9 +85,7 @@ pub struct WindowBorder {
     drawer: BorderDrawer,
     config: BorderConfig, // cached config values
     is_paused: bool,
-    last_reorder_time: Option<time::Instant>,
-    is_debouncing_reorder: bool,
-    consecutive_reorders: u64,
+    is_reorder_timer_pending: bool,
     arranged_override_active: bool, // radius override for arranged/snapped tracking window
 }
 
@@ -106,9 +105,7 @@ impl WindowBorder {
             drawer: Default::default(),
             config: Default::default(),
             is_paused: Default::default(),
-            last_reorder_time: None,
-            is_debouncing_reorder: false,
-            consecutive_reorders: 0,
+            is_reorder_timer_pending: false,
             arranged_override_active: false,
         });
 
@@ -428,23 +425,43 @@ impl WindowBorder {
                 | SWP_NOACTIVATE
                 | SWP_NOREDRAW
                 | other_flags.unwrap_or_default();
+            let is_active =
+                *APP_STATE.active_window.lock().unwrap() == self.tracking_window.0 as isize;
 
             let hwndinsertafter = match self.config.z_order {
                 ZOrderMode::AboveWindow => {
-                    // Get the hwnd above the tracking hwnd so we can place the border window in between
-                    let hwnd_above_tracking = GetWindow(self.tracking_window, GW_HWNDPREV);
+                    if is_active {
+                        // Keep the active border topmost so transient owned popups (IME candidate
+                        // windows) raised above the tracking window can't push it below it.
+                        HWND_TOPMOST
+                    } else {
+                        // Place inactive borders directly above their tracking window.
+                        let hwnd_above_tracking = GetWindow(self.tracking_window, GW_HWNDPREV);
 
-                    // If hwnd_above_tracking is the window border itself, we have what we want and there's
-                    // no need to change the z-order (plus it results in an error if we try it).
-                    if hwnd_above_tracking == Ok(self.border_window.0) {
-                        swp_flags |= SWP_NOZORDER;
+                        // If the window directly above the tracking window is already the border
+                        // itself, we have what we want and there's no need to change the z-order
+                        // (plus it results in an error if we try it).
+                        if hwnd_above_tracking == Ok(self.border_window.0) {
+                            swp_flags |= SWP_NOZORDER;
+                            HWND_NOTOPMOST
+                        } else {
+                            self.tracking_window
+                        }
                     }
-
-                    hwnd_above_tracking.unwrap_or(HWND_TOP)
                 }
                 ZOrderMode::BelowWindow => self.tracking_window,
             };
 
+            self.set_window_pos(hwndinsertafter, swp_flags)
+        }
+    }
+
+    fn set_window_pos(
+        &mut self,
+        hwndinsertafter: HWND,
+        swp_flags: SET_WINDOW_POS_FLAGS,
+    ) -> anyhow::Result<()> {
+        unsafe {
             if let Err(e) = SetWindowPos(
                 self.border_window.0,
                 Some(hwndinsertafter),
@@ -859,58 +876,26 @@ impl WindowBorder {
                     return LRESULT(0);
                 }
 
-                // Drain any pending WM_APP_REORDER messages from the queue
-                while unsafe {
-                    PeekMessageW(
-                        &mut MSG::default(),
-                        Some(self.border_window.0),
-                        WM_APP_REORDER,
-                        WM_APP_REORDER,
-                        PM_REMOVE,
-                    )
-                    .as_bool()
-                } {
-                    // Intentionally empty.
+                // Z-order churn (e.g. IME candidate updates) fires reorder events in bursts.
+                // Repositioning immediately on each one makes the border visibly flicker, so
+                // coalesce each burst into a single deferred reposition instead.
+                if !self.is_reorder_timer_pending {
+                    self.is_reorder_timer_pending = true;
+                    unsafe {
+                        SetTimer(
+                            Some(self.border_window.0),
+                            REORDER_TIMER_ID,
+                            REORDER_DEBOUNCE_DELAY_MS,
+                            None,
+                        )
+                    };
                 }
-
-                // Allows the immediate processing of some reorder messages, then debounces after
-                const NUM_REORDERS_BEFORE_DEBOUNCE: u64 = 8;
-                const DEBOUNCE_DELAY: time::Duration = time::Duration::from_millis(16);
-
-                if let Some(last_reorder_time) = self.last_reorder_time
-                    && let time_since_reorder = last_reorder_time.elapsed()
-                    && time_since_reorder < DEBOUNCE_DELAY
-                {
-                    self.consecutive_reorders += 1;
-                    if self.consecutive_reorders >= NUM_REORDERS_BEFORE_DEBOUNCE {
-                        if !self.is_debouncing_reorder {
-                            // Set a timer which fires a WM_TIMER message when it expires
-                            unsafe {
-                                SetTimer(
-                                    Some(self.border_window.0),
-                                    REORDER_TIMER_ID,
-                                    (DEBOUNCE_DELAY - time_since_reorder).as_millis() as u32,
-                                    None,
-                                )
-                            };
-                            self.is_debouncing_reorder = true;
-                        }
-
-                        return LRESULT(0);
-                    }
-                } else {
-                    self.consecutive_reorders = 0;
-                }
-
-                self.handle_reorder();
             }
             WM_TIMER => {
                 // WPARAM contains the nIDEvent used in SetTimer
                 if wparam.0 == REORDER_TIMER_ID {
                     unsafe { KillTimer(Some(window), REORDER_TIMER_ID) }.log_if_err();
-                    self.is_debouncing_reorder = false;
-                    self.consecutive_reorders = 0;
-
+                    self.is_reorder_timer_pending = false;
                     self.handle_reorder();
                 }
             }
@@ -922,6 +907,8 @@ impl WindowBorder {
                     return LRESULT(0);
                 }
 
+                // Places the active border at the topmost layer and inactive borders directly
+                // above their tracking window.
                 self.update_color(None);
                 self.update_position(None).log_if_err();
                 self.render().log_if_err();
@@ -1209,26 +1196,47 @@ impl WindowBorder {
     }
 
     fn handle_reorder(&mut self) {
+        // Active borders are kept topmost, so they're always above their tracking window. Only
+        // inactive borders need to re-check their position here.
+        let is_active = *APP_STATE.active_window.lock().unwrap() == self.tracking_window.0 as isize;
+
         match self.config.z_order {
             ZOrderMode::AboveWindow => {
-                // When the tracking window reorders its contents, it may change the z-order. So,
-                // we first check whether the border is still above the tracking window, and if
-                // not, we must update its position and place it back on top
-                if unsafe { GetWindow(self.tracking_window, GW_HWNDPREV) }
-                    != Ok(self.border_window.0)
-                {
+                if !is_active && !self.is_border_above_tracking() {
                     self.update_position(None).log_if_err();
                 }
             }
             ZOrderMode::BelowWindow => {
-                if unsafe { GetWindow(self.tracking_window, GW_HWNDNEXT) }
-                    != Ok(self.border_window.0)
-                {
+                if is_active && !self.is_border_below_tracking() {
                     self.update_position(None).log_if_err();
                 }
             }
         }
+    }
 
-        self.last_reorder_time = Some(time::Instant::now());
+    /// Whether the border is somewhere above the tracking window in the z-order. Transient
+    /// popups (tooltips, IME candidates, menus) can float between the two without the border
+    /// losing its spot above the tracking window, so those don't require repositioning.
+    fn is_border_above_tracking(&self) -> bool {
+        let mut window = self.tracking_window;
+        while let Ok(hwnd) = unsafe { GetWindow(window, GW_HWNDPREV) } {
+            if hwnd == self.border_window.0 {
+                return true;
+            }
+            window = hwnd;
+        }
+        false
+    }
+
+    /// Whether the border is somewhere below the tracking window in the z-order.
+    fn is_border_below_tracking(&self) -> bool {
+        let mut window = self.tracking_window;
+        while let Ok(hwnd) = unsafe { GetWindow(window, GW_HWNDNEXT) } {
+            if hwnd == self.border_window.0 {
+                return true;
+            }
+            window = hwnd;
+        }
+        false
     }
 }

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -20,13 +20,13 @@ use windows::Win32::UI::HiDpi::MDT_DEFAULT;
 use windows::Win32::UI::WindowsAndMessaging::{
     CREATESTRUCTW, CW_USEDEFAULT, CreateWindowExW, DBT_DEVNODES_CHANGED, DefWindowProcW,
     GW_HWNDNEXT, GW_HWNDPREV, GWLP_USERDATA, GetSystemMetrics, GetWindow, GetWindowLongPtrW,
-    HWND_NOTOPMOST, HWND_TOPMOST, KillTimer, LWA_ALPHA, PBT_APMRESUMEAUTOMATIC,
-    PBT_APMRESUMESUSPEND, PBT_APMSUSPEND, PostQuitMessage, SET_WINDOW_POS_FLAGS,
-    SM_CXVIRTUALSCREEN, SWP_HIDEWINDOW, SWP_NOACTIVATE, SWP_NOREDRAW, SWP_NOSENDCHANGING,
-    SWP_NOZORDER, SWP_SHOWWINDOW, SetLayeredWindowAttributes, SetTimer, SetWindowLongPtrW,
-    SetWindowPos, WM_CREATE, WM_DEVICECHANGE, WM_DISPLAYCHANGE, WM_DPICHANGED, WM_NCDESTROY,
-    WM_PAINT, WM_POWERBROADCAST, WM_TIMER, WM_WINDOWPOSCHANGED, WM_WINDOWPOSCHANGING, WS_DISABLED,
-    WS_EX_LAYERED, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_POPUP,
+    HWND_TOPMOST, KillTimer, LWA_ALPHA, PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND,
+    PBT_APMSUSPEND, PostQuitMessage, SET_WINDOW_POS_FLAGS, SM_CXVIRTUALSCREEN, SWP_HIDEWINDOW,
+    SWP_NOACTIVATE, SWP_NOREDRAW, SWP_NOSENDCHANGING, SWP_NOZORDER, SWP_SHOWWINDOW,
+    SetLayeredWindowAttributes, SetTimer, SetWindowLongPtrW, SetWindowPos, WM_CREATE,
+    WM_DEVICECHANGE, WM_DISPLAYCHANGE, WM_DPICHANGED, WM_NCDESTROY, WM_PAINT, WM_POWERBROADCAST,
+    WM_TIMER, WM_WINDOWPOSCHANGED, WM_WINDOWPOSCHANGING, WS_DISABLED, WS_EX_LAYERED,
+    WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_POPUP,
 };
 use windows::core::{PCWSTR, w};
 
@@ -425,43 +425,26 @@ impl WindowBorder {
                 | SWP_NOACTIVATE
                 | SWP_NOREDRAW
                 | other_flags.unwrap_or_default();
-            let is_active =
-                *APP_STATE.active_window.lock().unwrap() == self.tracking_window.0 as isize;
 
             let hwndinsertafter = match self.config.z_order {
+                ZOrderMode::AboveWindow if self.is_tracking_active() => {
+                    // Keep the active border topmost so transient owned popups (IME candidate
+                    // windows) raised above the tracking window can't push it below it.
+                    HWND_TOPMOST
+                }
                 ZOrderMode::AboveWindow => {
-                    if is_active {
-                        // Keep the active border topmost so transient owned popups (IME candidate
-                        // windows) raised above the tracking window can't push it below it.
-                        HWND_TOPMOST
-                    } else {
-                        // Place inactive borders directly above their tracking window.
-                        let hwnd_above_tracking = GetWindow(self.tracking_window, GW_HWNDPREV);
-
-                        // If the window directly above the tracking window is already the border
-                        // itself, we have what we want and there's no need to change the z-order
-                        // (plus it results in an error if we try it).
-                        if hwnd_above_tracking == Ok(self.border_window.0) {
-                            swp_flags |= SWP_NOZORDER;
-                            HWND_NOTOPMOST
-                        } else {
-                            self.tracking_window
-                        }
+                    // Place inactive borders directly above their tracking window.
+                    let hwnd_above_tracking = GetWindow(self.tracking_window, GW_HWNDPREV);
+                    if hwnd_above_tracking == Ok(self.border_window.0) {
+                        // The border is already directly above the tracking window.
+                        swp_flags |= SWP_NOZORDER;
                     }
+
+                    self.tracking_window
                 }
                 ZOrderMode::BelowWindow => self.tracking_window,
             };
 
-            self.set_window_pos(hwndinsertafter, swp_flags)
-        }
-    }
-
-    fn set_window_pos(
-        &mut self,
-        hwndinsertafter: HWND,
-        swp_flags: SET_WINDOW_POS_FLAGS,
-    ) -> anyhow::Result<()> {
-        unsafe {
             if let Err(e) = SetWindowPos(
                 self.border_window.0,
                 Some(hwndinsertafter),
@@ -481,6 +464,10 @@ impl WindowBorder {
         }
 
         Ok(())
+    }
+
+    fn is_tracking_active(&self) -> bool {
+        *APP_STATE.active_window.lock().unwrap() == self.tracking_window.0 as isize
     }
 
     fn update_color(&mut self, check_delay: Option<u64>) {
@@ -1198,7 +1185,7 @@ impl WindowBorder {
     fn handle_reorder(&mut self) {
         // Active borders are kept topmost, so they're always above their tracking window. Only
         // inactive borders need to re-check their position here.
-        let is_active = *APP_STATE.active_window.lock().unwrap() == self.tracking_window.0 as isize;
+        let is_active = self.is_tracking_active();
 
         match self.config.z_order {
             ZOrderMode::AboveWindow => {

--- a/src/window_border.rs
+++ b/src/window_border.rs
@@ -19,8 +19,8 @@ use windows::Win32::Graphics::Gdi::{CreateRectRgn, HMONITOR, ValidateRect};
 use windows::Win32::UI::HiDpi::MDT_DEFAULT;
 use windows::Win32::UI::WindowsAndMessaging::{
     CREATESTRUCTW, CW_USEDEFAULT, CreateWindowExW, DBT_DEVNODES_CHANGED, DefWindowProcW,
-    GW_HWNDNEXT, GW_HWNDPREV, GWLP_USERDATA, GetSystemMetrics, GetWindow, GetWindowLongPtrW,
-    HWND_TOPMOST, KillTimer, LWA_ALPHA, PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND,
+    GW_HWNDNEXT, GW_HWNDPREV, GWLP_HWNDPARENT, GWLP_USERDATA, GetSystemMetrics, GetWindow,
+    GetWindowLongPtrW, KillTimer, LWA_ALPHA, PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND,
     PBT_APMSUSPEND, PostQuitMessage, SET_WINDOW_POS_FLAGS, SM_CXVIRTUALSCREEN, SWP_HIDEWINDOW,
     SWP_NOACTIVATE, SWP_NOREDRAW, SWP_NOSENDCHANGING, SWP_NOZORDER, SWP_SHOWWINDOW,
     SetLayeredWindowAttributes, SetTimer, SetWindowLongPtrW, SetWindowPos, WM_CREATE,
@@ -152,6 +152,20 @@ impl WindowBorder {
                 anyhow!("could not get dpi for {:?}: {}", self.current_monitor, err)
             })?;
         self.load_from_config(window_rule, self.current_dpi)?;
+
+        if self.config.z_order == ZOrderMode::AboveWindow {
+            // Make the border an owned window of the tracking window so the system keeps it
+            // above its owner. This stops IME candidate popups (which are also owned windows of
+            // the focused window) from repeatedly pushing the border below it, without needing to
+            // make the border topmost.
+            unsafe {
+                SetWindowLongPtrW(
+                    self.border_window.0,
+                    GWLP_HWNDPARENT,
+                    self.tracking_window.0 as isize,
+                )
+            };
+        }
 
         // Delay the border while the tracking window is in its creation animation
         thread::sleep(time::Duration::from_millis(self.config.initialize_delay));
@@ -427,13 +441,9 @@ impl WindowBorder {
                 | other_flags.unwrap_or_default();
 
             let hwndinsertafter = match self.config.z_order {
-                ZOrderMode::AboveWindow if self.is_tracking_active() => {
-                    // Keep the active border topmost so transient owned popups (IME candidate
-                    // windows) raised above the tracking window can't push it below it.
-                    HWND_TOPMOST
-                }
                 ZOrderMode::AboveWindow => {
-                    // Place inactive borders directly above their tracking window.
+                    // The border is owned by the tracking window, so the system keeps it above
+                    // its owner. Just place it directly above to be sure.
                     let hwnd_above_tracking = GetWindow(self.tracking_window, GW_HWNDPREV);
                     if hwnd_above_tracking == Ok(self.border_window.0) {
                         // The border is already directly above the tracking window.


### PR DESCRIPTION
 ## Summary

  - Ignore reorder events emitted by tool and no-activate windows.
  - Route `EVENT_OBJECT_REORDER` only to the border associated with the event window instead of broadcasting it to every visible border.
  - Skip foreground updates when the active window has not actually changed.

  ## Problem

  IME candidate windows, such as Rime's candidate popup, emit client reorder events whenever their contents change. These events were previously broadcast to every visible border, causing borders torepeatedly correct their Z-order and visibly flicker.

  IME popups could also produce redundant foreground events, resulting in unnecessary border rendering and animation updates.

  ## Testing

  - `cargo fmt -- --check`
  - `cargo check --all-targets`
  - Compiled all test targets with `cargo test --all --no-run`
  - Manually verified with Rime that changing candidate text no longer causes the focused window border to flicker